### PR TITLE
Add ability to select subset of state with predicate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,18 @@ For more information on using storage enhancers check out [redux-localstorage](e
 ## API
 ### filter(paths)
 ```js
-type paths = Array<String> | String
+type paths = Array<String> | String | Function
 ```
-A path is a `string` that points to the property key of your redux store that you would like to persist. In order to specify a nested key separate the keys that make up the full path with fullstops (`.`). Specify multiple paths by passing in an `Array`: 
+A path is a `string` that points to the property key of your redux store that you would like to persist. In order to specify a nested key separate the keys that make up the full path with fullstops (`.`). Specify multiple paths by passing in an `Array`:
 
 ```js
 filter(['key', 'another.key']),
+```
+
+Specify dynamic keys by passing a predicate function that returns the subset of the state you'd like to persist:
+
+```js
+filter(state => state.items[state.items.length]),
 ```
 
 ## License

--- a/src/filter.js
+++ b/src/filter.js
@@ -57,7 +57,8 @@ export default function filter(paths) {
   return (storage) => ({
     ...storage,
     put: (key, state, callback) => {
-      storage.put(key, getSubset(state, finalPaths), callback);
+      const subset = typeof paths === 'function' ? paths(state) : getSubset(state, finalPaths);
+      storage.put(key, subset, callback);
     },
   });
 }


### PR DESCRIPTION
For persisting things that don't follow a predictable structure like [redux-orm](https://github.com/tommikaikkonen/redux-orm) slices of state, it'd be useful to pass a predicate function to determine what subset of the state to persist.
